### PR TITLE
BREAKING CHANGE: US135599 Lit 2 migration - Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "lit-element": "^3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "lit-element": "^3"
   }
 }


### PR DESCRIPTION
[US135599](https://rally1.rallydev.com/#/?detail=/userstory/623256588773&fdp=true): card-overlay, immersive-nav, ou-filter, pagination, toaster Lit 2 migration - Phase 2

This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 

- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules in `.github/dependabot.yml`
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers (Eg. `this._subscriptionController.hostConnected()`, etc)
- [x] backwards-compatible changes merged

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [x] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.
