### PR TITLE
fix: lit dependencies

### DIFF
--- a/card-overlay.js
+++ b/card-overlay.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3"
+    "lit": "^2"
   }
 }


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.